### PR TITLE
Added pause on onTapDown to mimic Instagram stories behaviour

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -166,7 +166,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.0+1"
   stream_channel:
     dependency: transitive
     description:
@@ -208,5 +208,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.2 <4.0.0"
+  dart: ">=2.18.2 <3.0.0"
   flutter: ">=1.16.0"

--- a/lib/story_page_view.dart
+++ b/lib/story_page_view.dart
@@ -445,6 +445,15 @@ class _Gestures extends StatelessWidget {
                   animationController!.forward();
                 }
               },
+              onLongPress: () {
+                animationController!.stop();
+              },
+              onLongPressUp: () {
+                if (storyImageLoadingController.value !=
+                    StoryImageLoadingState.loading) {
+                  animationController!.forward();
+                }
+              },
             ),
           ),
         ),
@@ -463,6 +472,15 @@ class _Gestures extends StatelessWidget {
                 animationController!.stop();
               },
               onTapUp: (_) {
+                if (storyImageLoadingController.value !=
+                    StoryImageLoadingState.loading) {
+                  animationController!.forward();
+                }
+              },
+              onLongPress: () {
+                animationController!.stop();
+              },
+              onLongPressUp: () {
                 if (storyImageLoadingController.value !=
                     StoryImageLoadingState.loading) {
                   animationController!.forward();

--- a/lib/story_page_view.dart
+++ b/lib/story_page_view.dart
@@ -459,10 +459,10 @@ class _Gestures extends StatelessWidget {
                       completeAnimation: () => animationController!.value = 1,
                     );
               },
-              onLongPress: () {
+              onTapDown: (_) {
                 animationController!.stop();
               },
-              onLongPressUp: () {
+              onTapUp: (_) {
                 if (storyImageLoadingController.value !=
                     StoryImageLoadingState.loading) {
                   animationController!.forward();

--- a/lib/story_page_view.dart
+++ b/lib/story_page_view.dart
@@ -436,10 +436,10 @@ class _Gestures extends StatelessWidget {
                 animationController!.forward(from: 0);
                 context.read<_StoryStackController>().decrement();
               },
-              onLongPress: () {
+              onTapDown: (_) {
                 animationController!.stop();
               },
-              onLongPressUp: () {
+              onTapUp: (_) {
                 if (storyImageLoadingController.value !=
                     StoryImageLoadingState.loading) {
                   animationController!.forward();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -177,5 +177,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.2 <4.0.0"
+  dart: ">=2.18.2 <3.0.0"
   flutter: ">=1.16.0"


### PR DESCRIPTION
Our users are used to Instagram and do not understand how to pause a story with a long press because in Instagram story pauses right on the tap start.